### PR TITLE
Changes required to deploy

### DIFF
--- a/solutions/ai-gateway-billing-sample/README.md
+++ b/solutions/ai-gateway-billing-sample/README.md
@@ -59,9 +59,10 @@ graph LR
 
 - [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.9
 - [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) — logged in (`az login`)
-- An Azure subscription with permissions to create:
-  - Resource groups, Cognitive Services (AI Foundry), API Management, Key Vault
-  - Entra ID app registrations (requires Application Administrator or equivalent)
+- An Azure subscription with permissions to:
+  - Create resource groups, Cognitive Services (AI Foundry), API Management, Key Vault
+  - Create Entra ID app registrations (requires Application Administrator or equivalent)
+  - Register resource providers
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) — Python package runner
 - [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) VS Code extension (optional, for `.http` tests)
 - *(Gemini only)* [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) — logged in (`gcloud auth application-default login`)

--- a/solutions/ai-gateway-billing-sample/infra/policies/api-openai.xml
+++ b/solutions/ai-gateway-billing-sample/infra/policies/api-openai.xml
@@ -27,8 +27,8 @@
         <!-- Fallback mapping (injected from Terraform) -->
         <set-variable name="fallback-map" value="${fallback_map_json}" />
         <!-- Route to backend based on model name -->
-        <choose>
 %{ if enable_gemini ~}
+        <choose>
             <when condition="@(new [] { ${gemini_models_csv} }.Contains((string)context.Variables["model-deployment"]))">
                 <!-- Gemini backend: rewrite URL, set Google API key auth -->
                 <set-backend-service id="set-gemini-backend" backend-id="${gemini_backend_id}" />
@@ -53,7 +53,6 @@
                     return body.ToString();
                 }</set-body>
             </when>
-%{ endif ~}
             <otherwise>
                 <!-- Foundry backend with managed identity auth -->
                 <set-backend-service id="set-chat-backend" backend-id="${chat_backend_id}" />
@@ -61,6 +60,12 @@
                 <authentication-managed-identity resource="https://cognitiveservices.azure.com/" />
             </otherwise>
         </choose>
+%{ else ~}
+        <!-- Foundry-only backend (Gemini disabled) -->
+        <set-backend-service id="set-chat-backend" backend-id="${chat_backend_id}" />
+        <set-variable name="is-gemini" value="false" />
+        <authentication-managed-identity resource="https://cognitiveservices.azure.com/" />
+%{ endif ~}
         <!-- Buffer request body to allow retry with different model -->
         <set-variable name="original-body" value="@(context.Request.Body.As&lt;string&gt;(preserveContent: true))" />
         <!-- Build fallback URL (used by send-request if primary fails) -->

--- a/solutions/ai-gateway-billing-sample/infra/providers.tf
+++ b/solutions/ai-gateway-billing-sample/infra/providers.tf
@@ -37,7 +37,9 @@ provider "azapi" {}
 provider "azuread" {}
 
 provider "google" {
-  project               = var.enable_gemini ? var.gcp_project_id : null
-  billing_project       = var.enable_gemini ? var.gcp_project_id : null
+  # Avoid ADC lookup for Azure-only deployments when Gemini is disabled.
+  project               = var.enable_gemini ? var.gcp_project_id : "placeholder-project"
+  billing_project       = var.enable_gemini ? var.gcp_project_id : "placeholder-project"
   user_project_override = var.enable_gemini
+  access_token          = var.enable_gemini ? null : "not-used-when-gemini-disabled"
 }

--- a/solutions/ai-gateway-billing-sample/infra/variables.tf
+++ b/solutions/ai-gateway-billing-sample/infra/variables.tf
@@ -78,7 +78,7 @@ variable "additional_chat_models" {
       version = "2024-07-18"
     }
     "gpt-5.1-chat" = {
-      version = "2025-06-01"
+      version = "2025-11-13"
     }
   }
 }


### PR DESCRIPTION
I ran into a few small hiccups when trying to deploy the Terraform plan:
- I needed to PIM on my tenant in order to register resource providers, so I called out the requirement in the README
- Even with the default of `enable_gemini: false`, the provider was trying to authenticate. I provided a dummy value (that should never get used) to prevent the auth lookup
- my Foundry deployment wouldn't let me deploy gpt-5.1-chat using that API version, so I had to bump it up to get the deployment working
- the APIM policy was malformed if `enable_gemini` was set to false. You'd end up with a <choose> and <otherwise>, but no <when> in it